### PR TITLE
hotfix: Corrige o carregamento da fonte League Spartan

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,6 +14,7 @@ const league = League_Spartan({
   fallback: ["Roboto", "sans-serif"],
   display: "swap",
   variable: "--font-league-spartan",
+  preload: true,
 });
 
 export const metadata: Metadata = {
@@ -55,7 +56,7 @@ export const metadata: Metadata = {
 import { GoogleTagManager } from "@next/third-parties/google";
 
 const RootLayout = ({ children }: { children: React.ReactNode }) => (
-  <html className={league.className} dir="ltr" lang="pt-BR">
+  <html className={league.variable} dir="ltr" lang="pt-BR">
     <head>
       <meta content="text/html" httpEquiv="content-type" />
     </head>


### PR DESCRIPTION
Este pull request corrige o carregamento da fonte League Spartan, que não estava sendo exibida corretamente ao rodar o código com `pnpm dev` na branch master.

As alterações foram feitas conforme a [documentação do Next.js](https://nextjs.org/docs/app/building-your-application/optimizing/fonts#with-tailwind-css) para configurações de fontes em projetos com Tailwind CSS. Além disso, esse pull request inclui a adição da opção `preload`, garantindo que a fonte seja pré-carregada em todas as rotas.

P.S.: É responsabilidade do mantenedor do repositório revisar e testar os pull requests antes de mergeá-los.